### PR TITLE
Set-up repo to utilize TailwindCSS for future styling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,6 @@ gem 'jekyll', '~> 4.4'
 group :jekyll_plugins do
   gem 'jekyll-feed'
   gem 'jekyll-paginate-v2'
+  gem 'jekyll-tailwindcss'
 end
+gem 'tailwindcss-ruby', '~> 4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
       jekyll (>= 3.0, < 5.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
+    jekyll-tailwindcss (0.7.0)
+      tailwindcss-ruby
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.9.1)
@@ -111,6 +113,13 @@ GEM
       google-protobuf (~> 4.29)
     sass-embedded (1.83.4-x86_64-linux-musl)
       google-protobuf (~> 4.29)
+    tailwindcss-ruby (4.1.7)
+    tailwindcss-ruby (4.1.7-aarch64-linux-gnu)
+    tailwindcss-ruby (4.1.7-aarch64-linux-musl)
+    tailwindcss-ruby (4.1.7-arm64-darwin)
+    tailwindcss-ruby (4.1.7-x86_64-darwin)
+    tailwindcss-ruby (4.1.7-x86_64-linux-gnu)
+    tailwindcss-ruby (4.1.7-x86_64-linux-musl)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
@@ -133,6 +142,8 @@ DEPENDENCIES
   jekyll (~> 4.4)
   jekyll-feed
   jekyll-paginate-v2
+  jekyll-tailwindcss
+  tailwindcss-ruby (~> 4.1)
 
 BUNDLED WITH
    2.6.2

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,9 @@
     <title>{{ page.title }} - {{ site.title }}</title>
     <link rel="shortcut icon" type="image/x-icon" href="{{ '/assets/images/favicon.ico' | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+    <!-- TODO include this stylesheet link when transitioning to TailwindCSS
+    <link rel="stylesheet" href="{{ '/assets/css/styles.css' | relative_url }}">
+    -->
   </head>
   <body>
     <a class="github-fork-ribbon" href="https://github.com/columbusrb/columbusrb.github.io" title="Fork me on GitHub" data-ribbon="Fork me on GitHub" target="_blank">Fork me on GitHub</a>

--- a/_tailwind.css
+++ b/_tailwind.css
@@ -1,0 +1,6 @@
+/*
+ * This file is used to define the tailwindcss theme and typography styles.
+ * It is @imported into the assets/css/styles.css file, and its output is included in the build.
+ */
+
+@import "tailwindcss";

--- a/assets/css/styles.tailwindcss
+++ b/assets/css/styles.tailwindcss
@@ -1,0 +1,4 @@
+---
+# This file will be converted to _site/assets/css/styles.css
+---
+This file is just a placeholder. It's content will be replaced by output from the tailwindcss CLI.


### PR DESCRIPTION
Following along with #4, I utilized the https://github.com/vormwald/jekyll-tailwindcss gem and followed along with the set-up directions.

Call-outs:
1. I pinned the version of TailwindCSS to 4.1 because by default the `tailwindcss-ruby` gem utilizes the latest version of Tailwind (which is currently 4.1 but guarding against future changes).
2. I included a commented-out link for actually utilizing the TailwindCSS stylesheet in the default layout. This was included but commented out so that the existing styling can stand until follow-up work is done to transition the styling to Tailwind.